### PR TITLE
Fix MongoDB port on README.md and add redis-server as service for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ group: edge
 sudo: required
 services:
   - mongodb
+  - redis-server
   - docker
 node_js:
   - "4.4.3"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install
 
 ### Setup MongoDB
 
-In order to run the Welcome server locally you'll need to have [MongoDB](https://www.mongodb.com/) installed and running on your local machine. 
+In order to run the Welcome server locally you'll need to have [MongoDB](https://www.mongodb.com/) installed and running on your local machine.
 
 Start MongoDB server with:
 
@@ -20,7 +20,7 @@ Start MongoDB server with:
 mongod
 ```
 
-By default, the Welcome server will try to access MongoDB on port `11211`, if you are running MongoDB on a different port you should set the `FH_MONGODB_CONN_URL` environment variable to the MongoDB connection URL.
+By default, the Welcome server will try to access MongoDB on port `27017`, if you are running MongoDB on a different port you should set the `FH_MONGODB_CONN_URL` environment variable to the MongoDB connection URL.
 
 ### Setup Redis
 
@@ -98,5 +98,3 @@ To get Plato's JavaScript source code visualization, static analysis, and comple
 ```
 npm run analysis
 ```
-
-


### PR DESCRIPTION
Fixed MongoDB default port on README.md as it was wrong.
Also added redis-server as service on travis. Test were passing without it, but some warnings could be found on the log.
