### PR TITLE
adds doc note re API key & bumps version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install
 
 In order to use the location based weather functionality within the app you will need a valid API key for the worldweatheronline.com service. An API key can be acquired [here](http://developer.worldweatheronline.com). 
 
-When you have a valid API key, add it to [lib/weather.js](https://github.com/feedhenry-templates/welcome-cloud/blob/master/lib/weather.js#L10):
+When you have a valid API key, add it to lib/weather.js:
 
 ```javascript
 // PLEASE ADD YOUR OWN API_KEY FOR http://developer.worldweatheronline.com

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Cloud template app for the Welcome project. It listens for FeedHenry SDK cloud c
 npm install
 ```
 
+## Weather data setup
+
+In order to use the location based weather functionality within the app you will need a valid API key for the worldweatheronline.com service. An API key can be acquired [here](http://developer.worldweatheronline.com). 
+
+When you have a valid API key, add it to [lib/weather.js](https://github.com/feedhenry-templates/welcome-cloud/blob/master/lib/weather.js#L10):
+
+```javascript
+// PLEASE ADD YOUR OWN API_KEY FOR http://developer.worldweatheronline.com
+var API_KEY = "yourNewKey";
+```
+
 ## Run locally
 
 ### Setup MongoDB

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "welcome-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "dependencies": {
     "express": "4.15.3",
     "fh-mbaas-api": "~7.0.15",


### PR DESCRIPTION
Adds a note to the readme that an API key needs to be added in order for the location-based weather calls to the cloud app to succeed. Also version bump as no version bump was made with this fix https://github.com/feedhenry-templates/welcome-cloud/commit/4681a605e34bd1398d76e4dca15b67a9985d9d00

Reference JIRA: https://issues.jboss.org/browse/RHMAP-16931

@jusanche @sedroche @thailekha @rachael-oregan simple docs PR & version bump - happy to merge if you are